### PR TITLE
When shuffling the decks, the discard and deck piles aren't reset

### DIFF
--- a/lib/models/deck_model.dart
+++ b/lib/models/deck_model.dart
@@ -21,6 +21,8 @@ class DeckModel {
 
   void shuffle({required final int numberOfDecks}) {
     this.numberOfDecks = numberOfDecks;
+    cardsDeckPile = [];
+    cardsDeckDiscarded = [];
 
     // Generate the specified number of decks
     for (int deckCount = 0; deckCount < numberOfDecks; deckCount++) {

--- a/test/models/deck_model_test.dart
+++ b/test/models/deck_model_test.dart
@@ -1,0 +1,22 @@
+import 'package:cards/models/game_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(
+    'DeckModel',
+    () {
+      test(
+        'shuffle should clear the previous state',
+        () {
+          DeckModel deck = DeckModel(2);
+
+          deck.shuffle(numberOfDecks: 2);
+          deck.cardsDeckDiscarded.add(deck.cardsDeckPile.removeLast());
+          deck.shuffle(numberOfDecks: 2);
+          expect(deck.cardsDeckDiscarded.length, 0);
+          expect(deck.cardsDeckPile.length, 108);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
When a game is done and selecting `Play Again`, this causes the non-used cards to be added to the deckPile.

Added test to verify